### PR TITLE
Fixed number bug in GUI of Math Riddles

### DIFF
--- a/lib/categories/Math/MathRiddlelLists.dart
+++ b/lib/categories/Math/MathRiddlelLists.dart
@@ -174,12 +174,14 @@ class ActionCard extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Container(
-                width: 10,
-                child: Text(
-                  number,
-                  style: TextStyle(
-                    fontWeight: FontWeight.bold,
-                    fontSize: 18,
+                width: 20,
+                child: Center(
+                  child: Text(
+                    number,
+                    style: TextStyle(
+                      fontWeight: FontWeight.bold,
+                      fontSize: 18,
+                    ),
                   ),
                 ),
               ),


### PR DESCRIPTION
I have fixed bug in which numbers were not aligned in row. 

I also added Center widget to properly align numbers.